### PR TITLE
Use array_replace_recursive instead of array_merge_recursive for import

### DIFF
--- a/Command/ImportCommand.php
+++ b/Command/ImportCommand.php
@@ -67,7 +67,7 @@ class ImportCommand extends ContainerAwareCommand
         $service->loadBundlesTranslationFiles($bundles, $locales, $domains);
 
         // merge translations
-        $allTranslations = array_merge_recursive($service->getTranslations(), $importTranslations);
+        $allTranslations = array_replace_recursive($service->getTranslations(), $importTranslations);
 
         // rewrite files (Bundle/domain.locale.yml)
         foreach ($allTranslations as $bundleName => $bundleTranslations) {


### PR DESCRIPTION
Hi,

Another small change.

If you use array_merge_recursive in the import command to merge the existing translations and the new ones, both the old and the new end up in the translation file as an array like so:
```
breadcrumb:
    registration:
        default: Registrations
        index: 'Registrations for'
        manual:
            - Manual
            - Инструкция
```

With array_replace_recursive the new translations overwrite the old translations, and the translations you haven't changed stay the same:
```
breadcrumb:
    registration:
        default: Registrations
        index: 'Registrations for'
        manual: Инструкция
```
Thanks in advance,


Sam