### PR TITLE
use the correct function to merge the existing translations with the new translations

### DIFF
--- a/src/Command/ImportCommand.php
+++ b/src/Command/ImportCommand.php
@@ -100,7 +100,7 @@ class ImportCommand extends Command
         $allTranslations = $importTranslations;
         // merge translations if we do not overwrite the data
         if (!$this->input->getOption('overwrite-existing')) {
-            $allTranslations = array_merge_recursive($this->loadService->getTranslations(), $importTranslations);
+            $allTranslations = array_replace_recursive($this->loadService->getTranslations(), $importTranslations);
         }
 
         // rewrite files (Bundle/domain.locale.yml)


### PR DESCRIPTION
array_merge_recursive has unwanted effects when the translation key is in both the exisiting and the new set. array_replace_recursive solves this